### PR TITLE
Add e2e tests for all pages

### DIFF
--- a/src/tests/Band/band.spec.ts
+++ b/src/tests/Band/band.spec.ts
@@ -1,0 +1,9 @@
+import test, { expect } from '@playwright/test';
+
+test.describe('Band page', () => {
+  test('should display band information', async ({ page }) => {
+    await page.goto('/band');
+    await expect(page).toHaveTitle(/La Banda - Rise/);
+    await expect(page.getByText('RISE es una banda', { exact: false })).toBeVisible();
+  });
+});

--- a/src/tests/Contact/contact.spec.ts
+++ b/src/tests/Contact/contact.spec.ts
@@ -1,0 +1,17 @@
+import test, { expect } from '@playwright/test';
+
+test.describe('Contact page', () => {
+  test('should submit contact form', async ({ page }) => {
+    await page.route('**/__contact-form.html', route => route.fulfill({ status: 200, body: 'OK' }));
+    await page.goto('/contact');
+    await expect(page).toHaveTitle(/Contáctanos - Rise/);
+    await expect(page.getByRole('heading', { name: 'Contacto' })).toBeVisible();
+
+    await page.fill('input[name="name"]', 'Test User');
+    await page.fill('input[name="email"]', 'user@example.com');
+    await page.fill('textarea[name="message"]', 'Hello');
+    await page.click('button[type="submit"]');
+
+    await expect(page.getByText('Gracias por ponerte en contacto', { exact: false })).toBeVisible();
+  });
+});

--- a/src/tests/Navigation/navigation.spec.ts
+++ b/src/tests/Navigation/navigation.spec.ts
@@ -1,0 +1,33 @@
+import test, { expect } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  const navLinks = [
+    { label: 'La Banda', path: '/band' },
+    { label: 'Tienda', path: '/shop' },
+    { label: 'Tour', path: '/tour' },
+    { label: 'Contacto', path: '/contact' },
+  ];
+
+  for (const { label, path } of navLinks) {
+    test(`navigate to ${label}`, async ({ page }) => {
+      await page.goto('/');
+      await page.getByRole('link', { name: label }).click();
+      await expect(page).toHaveURL(path);
+    });
+  }
+
+  const footerLinks = [
+    { label: 'Aviso Legal', path: '/legal' },
+    { label: 'Política de Cookies Web', path: '/cookies' },
+    { label: 'Política de Privacidad Web', path: '/privacy' },
+    { label: 'Términos y condiciones Web', path: '/terms' },
+  ];
+
+  for (const { label, path } of footerLinks) {
+    test(`footer link ${label}`, async ({ page }) => {
+      await page.goto('/');
+      await page.getByRole('link', { name: label }).click();
+      await expect(page).toHaveURL(path);
+    });
+  }
+});

--- a/src/tests/Policies/policies.spec.ts
+++ b/src/tests/Policies/policies.spec.ts
@@ -1,0 +1,18 @@
+import test, { expect } from '@playwright/test';
+
+test.describe('Policy pages', () => {
+  const pages = [
+    { path: '/cookies', title: /Cookies - Rise/, heading: 'Cookies' },
+    { path: '/legal', title: /Aviso legal - Rise/, heading: 'Aviso Legal' },
+    { path: '/privacy', title: /Privacidad - Rise/, heading: 'Privacidad' },
+    { path: '/terms', title: /Terminos y condiciones - Rise/, heading: 'Términos & Condiciones' },
+  ];
+
+  for (const { path, title, heading } of pages) {
+    test(`should render ${path}`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page).toHaveTitle(title);
+      await expect(page.getByRole('heading', { name: heading })).toBeVisible();
+    });
+  }
+});

--- a/src/tests/Shop/purchase-flow.spec.ts
+++ b/src/tests/Shop/purchase-flow.spec.ts
@@ -1,0 +1,20 @@
+import test, { expect } from '@playwright/test';
+
+test.describe('Shop purchase flow', () => {
+  test('should submit purchase form and show success', async ({ page }) => {
+    await page.route('**/__purchase-form.html', route => route.fulfill({ status: 200, body: 'OK' }));
+
+    await page.goto('/shop');
+    await page.getByText('Breathing Again Album').first().click();
+    await expect(page).toHaveURL(/#purchase-form/);
+
+    await page.getByText('Breathing Again Album').first().click();
+    await page.getByText('Gastos de envío').first().click();
+
+    await page.fill('input[name="name"]', 'Test User');
+    await page.fill('input[name="email"]', 'user@example.com');
+
+    await page.click('button[type="submit"]');
+    await expect(page.getByText('Te contactaremos', { exact: false })).toBeVisible();
+  });
+});

--- a/src/tests/Shop/shop.spec.ts
+++ b/src/tests/Shop/shop.spec.ts
@@ -18,7 +18,7 @@ test.describe('Shop page', () => {
       await expect(page.getByText(name)).toBeVisible();
     }
 
-    await page.getByText('Breathing Again Album').click();
+    await page.getByText('Frank T-Shirt').click();
     await expect(page).toHaveURL(/#purchase-form/);
   });
 });

--- a/src/tests/Shop/shop.spec.ts
+++ b/src/tests/Shop/shop.spec.ts
@@ -1,7 +1,6 @@
 import test, { expect } from '@playwright/test';
 
 const articleNames = [
-  'Breathing Again Album',
   'Frank T-Shirt',
   'Breathing Again T-Shirt',
   'Derange Album',
@@ -13,6 +12,7 @@ test.describe('Shop page', () => {
   test('should display articles and purchase form', async ({ page }) => {
     await page.goto('/shop');
     await expect(page).toHaveTitle(/La Tienda - Rise/);
+    await expect(page.getByText('Breathing Again Album')).toHaveCount(2);
 
     for (const name of articleNames) {
       await expect(page.getByText(name)).toBeVisible();

--- a/src/tests/Shop/shop.spec.ts
+++ b/src/tests/Shop/shop.spec.ts
@@ -1,0 +1,24 @@
+import test, { expect } from '@playwright/test';
+
+const articleNames = [
+  'Breathing Again Album',
+  'Frank T-Shirt',
+  'Breathing Again T-Shirt',
+  'Derange Album',
+  'Pack Frank + Album',
+  'Pack Breathing Again'
+];
+
+test.describe('Shop page', () => {
+  test('should display articles and purchase form', async ({ page }) => {
+    await page.goto('/shop');
+    await expect(page).toHaveTitle(/La Tienda - Rise/);
+
+    for (const name of articleNames) {
+      await expect(page.getByText(name)).toBeVisible();
+    }
+
+    await page.getByText('Breathing Again Album').click();
+    await expect(page).toHaveURL(/#purchase-form/);
+  });
+});

--- a/src/tests/Shop/shop.spec.ts
+++ b/src/tests/Shop/shop.spec.ts
@@ -1,6 +1,7 @@
 import test, { expect } from '@playwright/test';
 
 const articleNames = [
+  'Breathing Again Album',
   'Frank T-Shirt',
   'Breathing Again T-Shirt',
   'Derange Album',
@@ -12,13 +13,12 @@ test.describe('Shop page', () => {
   test('should display articles and purchase form', async ({ page }) => {
     await page.goto('/shop');
     await expect(page).toHaveTitle(/La Tienda - Rise/);
-    await expect(page.getByText('Breathing Again Album')).toHaveCount(2);
 
     for (const name of articleNames) {
-      await expect(page.getByText(name)).toBeVisible();
+      await expect(page.getByText(name)).toHaveCount(2)
     }
 
-    await page.getByText('Frank T-Shirt').click();
+    await page.getByText('Frank T-Shirt').first().click();
     await expect(page).toHaveURL(/#purchase-form/);
   });
 });

--- a/src/tests/Tour/tour.spec.ts
+++ b/src/tests/Tour/tour.spec.ts
@@ -1,0 +1,17 @@
+import test, { expect } from '@playwright/test';
+
+test.describe('Tour page', () => {
+  test('should submit tour form', async ({ page }) => {
+    await page.route('**/__tour-form.html', route => route.fulfill({ status: 200, body: 'OK' }));
+    await page.goto('/tour');
+    await expect(page).toHaveTitle(/Tour - Rise/);
+    await expect(page.getByRole('heading', { name: 'Tour' })).toBeVisible();
+
+    await page.fill('input[name="name"]', 'Test User');
+    await page.fill('input[name="email"]', 'user@example.com');
+    await page.fill('textarea[name="message"]', 'Hello');
+    await page.click('button[type="submit"]');
+
+    await expect(page.getByText('Gracias por ponerte en contacto', { exact: false })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add e2e tests for Band page
- add e2e tests for Contact page form
- add e2e tests for Tour page form
- add e2e tests for Shop page
- add policy page tests
- add navigation tests for navbar and footer

## Testing
- `pnpm playwright:local` *(fails: Command "playwright" not found)*

------
https://chatgpt.com/codex/tasks/task_e_686419cb76b48329a94d687bf023b403